### PR TITLE
(SIMP-2733) Check for gdm_version

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,6 +1,9 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check
---no-80chars-check
+--no-140chars-check
+--no-empty_string-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+# This is here because the code can't handle lookups in parameters and we have
+# a LOT of those
+--no-parameter_order-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
 sudo: false
@@ -24,17 +27,17 @@ env:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.8.1"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.2.0"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Feb 21 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.1-0
+- Added check for gdm_version before it's used
+
 * Tue Dec 13 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.0-0
 - Added strong typing of parameters
 

--- a/manifests/dconf.pp
+++ b/manifests/dconf.pp
@@ -1,9 +1,8 @@
-# gnome::dconf class
-#
 # Uses dconf to configure settings in gnome 3 and higher.
 #
-#
-# @param profile_list An array of dconf profiles
+# @param profile_list A list of profiles used to ensure the directories are
+#   created. Should probably add a check to ensure you can't use a profile
+#   value that is not first defined here.
 #
 # @param base The dconf directory.  This really shouldn't change.
 #
@@ -12,20 +11,16 @@
 #
 # @author Ralph Wright <rwright@onyxpoint.com>
 #
-
-class gnome::dconf
-(
-  # A list of profiles used to ensure the directories are created
-  # Should probably add a check to ensure you can't use a profile value that is not first defined here.
-  Array[String] $profile_list = ['simp','gdm'],
+class gnome::dconf (
+  Array[String]        $profile_list = ['simp','gdm'],
   Stdlib::Absolutepath $base = '/etc/dconf',
   # Fix the source of the content
   String $banner = "'--------------------------------- ATTENTION ----------------------------------\\n\\n                         THIS IS A RESTRICTED COMPUTER SYSTEM\\n\\nThis computer system, and all related equipment, networks, and\\nnetwork devices are provided for authorised use only.  All \\nsystems controlled by this organisation will be monitored for\\nall lawful purposes.  Monitoring includes the totality of the\\noperating system and connected networks.No events on this\\nsystem are excluded from record and there are no exclusions\\nfrom this policy.\\n\\nUse of this system constitutes consent to full monitoring of\\nyour activities for use by the authorised monitoring organisation.\\nUnauthorised use of this system, including uninvited connections,\\nmay subject you to criminal prosecution.\\n\\nThe data collected from this system may be used for any purpose by\\nthe collecting organisation.  If you do not agree to this\\nmonitoring, discontinue use of the system IMMEDIATELY.\\n\\n                         THIS IS A RESTRICTED COMPUTER SYSTEM\\n\\n--------------------------------- ATTENTION ----------------------------------'"
-){
+) {
 
   # Create an array of directories based on profile names
   $locks_dir = regsubst($profile_list, '^(.*)$', '/etc/dconf/db/\1.d/locks')
-  $dir = regsubst($profile_list, '^(.*)$', '/etc/dconf/db/\1.d')
+  $dir       = regsubst($profile_list, '^(.*)$', '/etc/dconf/db/\1.d')
 
   file { $dir :
     ensure => 'directory',

--- a/manifests/dconf/add.pp
+++ b/manifests/dconf/add.pp
@@ -1,5 +1,3 @@
-# define gnome::dconf::add
-#
 # Add a dconf rule to the profile of your choice
 #
 # This adds a configuration file to the /etc/dconf/db/<profile>.d directory.
@@ -18,19 +16,20 @@
 # @param base_dir The database base directory
 #
 # @param lock Boolean to lock the key from being changed by general users.
-
+#
 define gnome::dconf::add (
-  String $key,
+  String                  $key,
   Variant[Boolean,String] $value,
-  String $profile,
-  String $path,
-  Stdlib::Absolutepath $base_dir = '/etc/dconf/db',
-  Boolean $lock = true
+  String                  $profile,
+  String                  $path,
+  Stdlib::Absolutepath    $base_dir = '/etc/dconf/db',
+  Boolean                 $lock = true
 ){
   include '::gnome::dconf'
-  $profile_list = $::gnome::dconf::profile_list
-  $target_file = "${base_dir}/${profile}.d/${name}"
-  $dconf_lock = "/${path}/${key}"
+
+  $profile_list    = $::gnome::dconf::profile_list
+  $target_file     = "${base_dir}/${profile}.d/${name}"
+  $dconf_lock      = "/${path}/${key}"
   $dconf_lock_path = "${base_dir}/${profile}.d/locks"
 
   file { $target_file :

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class gnome(
     $package_list = [
       'alacarte',
       'gnome-shell',
+      'gnome-session-xsession',
       'im-chooser',
       'nautilus',
       'orca',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,4 @@
-# class gnome
-#
 # Installs basic packages for gnome environment.
-#
-# == Parameters
 #
 # @param enable_screensaver Whether or not to include gnome::screensaver
 #
@@ -66,7 +62,11 @@ class gnome(
   }
 
   # Basic useful packages
-  $package_list_before = $enable_screensaver ? { true => Class['::gnome::screensaver'], default => undef}
+  $package_list_before = $enable_screensaver ? {
+    true    => Class['::gnome::screensaver'],
+    default => undef
+  }
+
   package { $package_list :
     ensure => 'latest',
     before => $package_list_before

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,14 +5,17 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class gnome(
-    Boolean $enable_screensaver = true,
+  Boolean $enable_screensaver = true,
 ) {
 
   if $enable_screensaver {
     include '::gnome::screensaver'
   }
 
-  if ( versioncmp($::operatingsystemmajrelease, '6')  > 0 ) {
+  # This should be a case statement using the gdm_version fact, but it will
+  # be left to toggle on major oc version to reduce the number of changes
+  # required on the second run of the module.
+  if $facts['os']['release']['major'] == '6' {
     $package_list = [
       'alacarte',
       'at-spi2-atk',
@@ -37,28 +40,12 @@ class gnome(
   } else {
     $package_list = [
       'alacarte',
-      'at-spi',
-      'control-center',
-      'gnome-applets',
-      'gnome-mag',
-      'gnome-panel',
-      'gnome-power-manager',
-      'gnome-screensaver',
-      'gnome-session',
-      'gnome-terminal',
-      'gnome-user-docs',
-      'gnome-utils',
+      'gnome-shell',
       'im-chooser',
       'nautilus',
-      'nautilus-open-terminal',
       'orca',
-      'sabayon-apply',
       'yelp'
     ]
-  }
-
-  if !defined(Package['gdm']) {
-    package { 'gdm': ensure => latest }
   }
 
   # Basic useful packages
@@ -70,6 +57,10 @@ class gnome(
   package { $package_list :
     ensure => 'latest',
     before => $package_list_before
+  }
+
+  if !defined(Package['gdm']) {
+    package { 'gdm': ensure => latest }
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@ class gnome(
       'alacarte',
       'gnome-shell',
       'gnome-session-xsession',
+      'gnome-terminal',
       'im-chooser',
       'nautilus',
       'orca',

--- a/manifests/screensaver.pp
+++ b/manifests/screensaver.pp
@@ -1,12 +1,10 @@
-# class gnome::screensaver
-#
 # Some default tweaks for securing Gnome.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class gnome::screensaver {
 
-  if ( versioncmp($::operatingsystemmajrelease, '6') > 0 ) {
+  if $facts['os']['release']['major'] == '6' {
     # TODO: Screensaver settings here
   } else {
     gconf { 'screensaver_enabled':
@@ -28,7 +26,9 @@ class gnome::screensaver {
   }
 
   # If gdm is greater than 3, then we need to use dconf to secure the desktop
-  if ( versioncmp($::gdm_version, '3') >= 0 ) {
+  # Also, the existance of the gdm_version fact needs to be checked, otherwise
+  #   compilation will fail
+  if $facts['gdm_version'] and ( versioncmp($facts['gdm_version'], '3') >= 0 ) {
     include '::gnome::dconf'
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-gnome",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author": "SIMP Team",
   "summary": "provides useful settings to set up GNOME.",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'gnome' do
-context 'supported operating systems' do
+  context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts.merge( { :gdm_version => '3.20.1' } ) }
+        let(:facts) do
+          os_facts[:gdm_version] = '3.20.1'
+          os_facts
+        end
 
         let(:params) { {:enable_screensaver => true} }
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('gnome') }
         it { is_expected.to contain_class('gnome::screensaver') }
-        if os_facts[:operatingsystemmajrelease].to_s > '6'
+        if os_facts[:os][:release][:major] == '6'
           $package_list = [
             'alacarte',
             'at-spi2-atk',
@@ -36,22 +39,10 @@ context 'supported operating systems' do
         else
           $package_list = [
             'alacarte',
-            'at-spi',
-            'control-center',
-            'gnome-applets',
-            'gnome-mag',
-            'gnome-panel',
-            'gnome-power-manager',
-            'gnome-screensaver',
-            'gnome-session',
-            'gnome-terminal',
-            'gnome-user-docs',
-            'gnome-utils',
+            'gnome-shell',
             'im-chooser',
             'nautilus',
-            'nautilus-open-terminal',
             'orca',
-            'sabayon-apply',
             'yelp'
           ]
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,6 +40,8 @@ describe 'gnome' do
           $package_list = [
             'alacarte',
             'gnome-shell',
+            'gnome-session-xsession',
+            'gnome-terminal',
             'im-chooser',
             'nautilus',
             'orca',

--- a/spec/classes/screensaver_spec.rb
+++ b/spec/classes/screensaver_spec.rb
@@ -4,22 +4,30 @@ describe 'gnome::screensaver' do
 context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts.merge( { :gdm_version => '3.20.1' } ) }
+        let(:facts) do
+          os_facts[:gdm_version] = '3.20.1'
+          os_facts
+        end
+
         it { is_expected.to compile.with_all_deps }
-        if os_facts[:operatingsystemmajrelease].to_s <= '6'
+
+        if os_facts[:os][:release][:major] == 6
           it { is_expected.to create_class('gnome::screensaver') }
           it { is_expected.to contain_gconf('screensaver_enabled') }
           it { is_expected.to contain_gconf('screensaver_timeout') }
           it { is_expected.to contain_gconf('screensaver_lock') }
         end
+
         context 'with gdm version < 3' do
           let(:facts) { os_facts.merge( { :gdm_version => '2.0' } ) }
           it { is_expected.to_not contain_class('gnome::dconf') }
         end
+
         context 'with gdm version >= 3' do
           let(:facts) { os_facts.merge( { :gdm_version => '3.0' } ) }
           it { is_expected.to contain_class('gnome::dconf') }
         end
+
       end
     end
   end

--- a/spec/classes/screensaver_spec.rb
+++ b/spec/classes/screensaver_spec.rb
@@ -19,12 +19,18 @@ context 'supported operating systems' do
         end
 
         context 'with gdm version < 3' do
-          let(:facts) { os_facts.merge( { :gdm_version => '2.0' } ) }
+          let(:facts) do
+            os_facts[:gdm_version] = '2.0'
+            os_facts
+          end
           it { is_expected.to_not contain_class('gnome::dconf') }
         end
 
         context 'with gdm version >= 3' do
-          let(:facts) { os_facts.merge( { :gdm_version => '3.0' } ) }
+          let(:facts) do
+            os_facts[:gdm_version] = '3.0'
+            os_facts
+          end
           it { is_expected.to contain_class('gnome::dconf') }
         end
 


### PR DESCRIPTION
gdm_version is set to undef on the first run, while the gdm package is
installed. After the first run, the file that the gdm_version fact is
confined to exists. Now the logic that includes versioncmp will check
for the existence of gdm_version before running the versioncmp.

SIMP-2733 #close