### PR TITLE
(SIMP-3126) dconf update fails if misconfigured

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Mon Apr 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.3-0
 - Updated polkit setting to use the new defined type from the polkit module
 - Added polkit dependency
+- `dconf update` execs now catch failures
 
 * Mon Mar 15 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.0.2-0
 - Fixed packages lists

--- a/manifests/dconf.pp
+++ b/manifests/dconf.pp
@@ -18,8 +18,8 @@ class gnome::dconf (
 ) {
   $_banner = $banner ? {
     String  => $banner,
-    default => @(EOF)
-      --------------------------------- ATTENTION ----------------------------------
+    default => @(EOF).split("\n").join('\n')
+      '--------------------------------- ATTENTION ----------------------------------
 
                                THIS IS A RESTRICTED COMPUTER SYSTEM
 
@@ -42,7 +42,7 @@ class gnome::dconf (
 
                                THIS IS A RESTRICTED COMPUTER SYSTEM
 
-      --------------------------------- ATTENTION ----------------------------------
+      --------------------------------- ATTENTION ----------------------------------'
       |EOF
   }
 

--- a/manifests/dconf/add.pp
+++ b/manifests/dconf/add.pp
@@ -54,8 +54,10 @@ define gnome::dconf::add (
   # Ensure the lock file is removed if lock is set to false
   else { file { "${dconf_lock_path}/${name}" : ensure => absent}}
 
+  # `dconf update` doesn't return an exit code, so we have to make one
+  # if the command returns output, it failed
   exec {"dconf_update_${name}":
-    command     => '/bin/dconf update',
+    command     => '/bin/dconf update |& wc -c | grep ^0$',
     umask       => '0033',
     refreshonly => true
   }


### PR DESCRIPTION
Previously, the `dconf update` command would run successfully if there
was an error parsing the dconf db. The error should now cause the exec
resource to fail.

SIMP-3126 #close