### PR TITLE
(SIMP-3135) Move user dconf db above simp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Thu May 04 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
+* Thu May 04 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.3-0
 - Moved the simp dconf profile below the user profile so users can change
   their own settings in the desktop
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu May 04 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
+- Moved the simp dconf profile below the user profile so users can change
+  their own settings in the desktop
+
 * Thu Apr 27 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.0.3-0
 - Add dconf rule to not display user lists
 

--- a/manifests/dconf.pp
+++ b/manifests/dconf.pp
@@ -63,7 +63,7 @@ class gnome::dconf (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => "system-db:simp\nuser-db:user\nsystem-db:local\nsystem-db:site\nsystem-db:distro",
+    content => "user-db:user\nsystem-db:simp\nsystem-db:local\nsystem-db:site\nsystem-db:distro",
   }
 
   # Everything below this sets the actual values we care about

--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,16 @@
 {
   "name": "simp-gnome",
-  "version": "6.0.3",
+  "version": "6.1.0",
   "author": "SIMP Team",
-  "summary": "provides useful settings to set up GNOME.",
+  "summary": "Provides useful settings to set up the GNOME desktop environment",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-gnome",
   "project_page": "https://github.com/simp/pupmod-simp-gnome",
   "issues_url": "https://github.com/simp/pupmod-simp-gnome/issues",
   "tags": [
     "simp",
-    "gnome"
+    "gnome",
+    "desktop"
   ],
   "dependencies": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-gnome",
-  "version": "6.1.0",
+  "version": "6.0.3",
   "author": "SIMP Team",
   "summary": "Provides useful settings to set up the GNOME desktop environment",
   "license": "Apache-2.0",

--- a/spec/classes/dconf_spec.rb
+++ b/spec/classes/dconf_spec.rb
@@ -11,7 +11,7 @@ describe 'gnome::dconf' do
       context 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('gnome::dconf') }
-        it { is_expected.to create_file('/etc/dconf/profile/user').with_content("system-db:simp\nuser-db:user\nsystem-db:local\nsystem-db:site\nsystem-db:distro") }
+        it { is_expected.to create_file('/etc/dconf/profile/user').with_content("user-db:user\nsystem-db:simp\nsystem-db:local\nsystem-db:site\nsystem-db:distro") }
         it { is_expected.to create_polkit__authorization__basic_policy('Allow anyone to shutdown system') }
         it { is_expected.to create_polkit__authorization__basic_policy('Allow anyone to restart system') }
 


### PR DESCRIPTION
This change will allow users to make changes to their own desktop
environments.

SIMP-3135 #close