### PR TITLE
Finalize RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -117,6 +117,7 @@ jobs:
             puppet_version: '~> 8.0'
             ruby_version: 3.1
             experimental: true
+      fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
@@ -129,7 +130,6 @@ jobs:
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
         continue-on-error: ${{matrix.puppet.experimental}}
-        fail-fast: false
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 /junit
 /log
 /doc
+/Gemfile.lock

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -24,13 +24,13 @@ Installs and configures a minimal Gnome environment
 
 The following parameters are available in the `gnome` class:
 
-* [`configure`](#configure)
-* [`dconf_hash`](#dconf_hash)
-* [`dconf_profile_hierarchy`](#dconf_profile_hierarchy)
-* [`packages`](#packages)
-* [`package_ensure`](#package_ensure)
+* [`configure`](#-gnome--configure)
+* [`dconf_hash`](#-gnome--dconf_hash)
+* [`dconf_profile_hierarchy`](#-gnome--dconf_profile_hierarchy)
+* [`packages`](#-gnome--packages)
+* [`package_ensure`](#-gnome--package_ensure)
 
-##### <a name="configure"></a>`configure`
+##### <a name="-gnome--configure"></a>`configure`
 
 Data type: `Boolean`
 
@@ -38,7 +38,7 @@ Use the module to configure Gnome
 
 @see data/common.yaml
 
-##### <a name="dconf_hash"></a>`dconf_hash`
+##### <a name="-gnome--dconf_hash"></a>`dconf_hash`
 
 Data type: `Hash[String[1], Dconf::SettingsHash]`
 
@@ -47,7 +47,7 @@ dconf settings specific to Gnome 3
 @see data/common.yaml
 @see https://wiki.gnome.org/Projects/dconf/SystemAdministrators
 
-##### <a name="dconf_profile_hierarchy"></a>`dconf_profile_hierarchy`
+##### <a name="-gnome--dconf_profile_hierarchy"></a>`dconf_profile_hierarchy`
 
 Data type: `Dconf::DBSettings`
 
@@ -56,7 +56,7 @@ Dconf db priority
 @see https://help.gnome.org/admin/system-admin-guide/stable/dconf.html.en
 @see https://wiki.gnome.org/Projects/dconf/SystemAdministrators
 
-##### <a name="packages"></a>`packages`
+##### <a name="-gnome--packages"></a>`packages`
 
 Data type: `Hash[String[1], Optional[Hash]]`
 
@@ -71,7 +71,7 @@ A Hash of packages to be installed
 
 @see data/common.yaml
 
-##### <a name="package_ensure"></a>`package_ensure`
+##### <a name="-gnome--package_ensure"></a>`package_ensure`
 
 Data type: `Simplib::PackageEnsure`
 


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.